### PR TITLE
Fixed validation handling in min, max, and compare functions

### DIFF
--- a/src/compare/index.ts
+++ b/src/compare/index.ts
@@ -1,33 +1,6 @@
 import { isValidDateOrNumber } from "../_lib/validators";
 
 /**
- * Validates and converts a Date or number input to a Date object.
- * @internal
- */
-function validateAndConvertDate(
-  input: Date | number,
-  argumentName: "First" | "Second"
-): Date {
-  if (typeof input === "number") {
-    // New feature: Accept number inputs (timestamps)
-    const date = new Date(input);
-    if (!isValidDateOrNumber(date)) {
-      throw new RangeError(`${argumentName} date is invalid`);
-    }
-    return date;
-  } else if (input instanceof Date) {
-    // Existing feature: Accept Date objects
-    if (!isValidDateOrNumber(input)) {
-      throw new RangeError(`${argumentName} date is invalid`);
-    }
-    return input;
-  } else {
-    // Backward compatibility: Original error message for invalid types
-    throw new RangeError(`${argumentName} argument must be a Date object`);
-  }
-}
-
-/**
  * Compare two Date objects or timestamps chronologically.
  *
  * @param date1 - The first Date object or timestamp to compare
@@ -73,11 +46,14 @@ function validateAndConvertDate(
 export function compare(
   date1: Date | number,
   date2: Date | number,
-  order?: "ASC" | "DESC"
+  order?: "ASC" | "DESC",
 ): number {
+  // Validate inputs early for NaN cases
+  if (!isValidDateOrNumber(date1) || !isValidDateOrNumber(date2)) return NaN;
+
   // Validate and convert inputs using helper function
-  const dateLeft = validateAndConvertDate(date1, "First");
-  const dateRight = validateAndConvertDate(date2, "Second");
+  const dateLeft = new Date(date1);
+  const dateRight = new Date(date2);
 
   // Order parameter normalization (case-insensitive, default to ASC for invalid values)
   let normalizedOrder: "ASC" | "DESC" = "ASC";
@@ -104,3 +80,4 @@ export function compare(
   // Apply order adjustment for descending sort
   return normalizedOrder === "DESC" ? -result : result;
 }
+

--- a/src/max/index.ts
+++ b/src/max/index.ts
@@ -29,9 +29,7 @@
  * ```
  */
 export function max(...dates: (Date | number)[]): Date {
-  if (dates.length === 0) {
-    throw new Error("max requires at least one date argument");
-  }
+  if (dates.length === 0) return new Date(NaN);
 
   // Convert all inputs to Date objects and check validity
   const dateObjects: Date[] = [];
@@ -52,3 +50,4 @@ export function max(...dates: (Date | number)[]): Date {
 
   return new Date(maxDate.getTime());
 }
+

--- a/src/min/index.ts
+++ b/src/min/index.ts
@@ -29,9 +29,7 @@
  * ```
  */
 export function min(...dates: (Date | number)[]): Date {
-  if (dates.length === 0) {
-    throw new Error("min requires at least one date argument");
-  }
+  if (dates.length === 0) return new Date(NaN);
 
   // Convert all inputs to Date objects and check validity
   const dateObjects: Date[] = [];
@@ -52,3 +50,4 @@ export function min(...dates: (Date | number)[]): Date {
 
   return new Date(minDate.getTime());
 }
+

--- a/tests/compare.test.ts
+++ b/tests/compare.test.ts
@@ -1,78 +1,81 @@
-import { describe, it, expect } from 'vitest';
-import { compare } from '../src/compare/index.js';
+import { describe, it, expect } from "vitest";
+import { compare } from "../src/compare/index.js";
 
-describe('compare', () => {
+describe("compare", () => {
   // T003: Contract tests based on compare.contract.ts
-  describe('Contract tests', () => {
-    describe('Ascending order (default)', () => {
+  describe("Contract tests", () => {
+    describe("Ascending order (default)", () => {
       it.each([
         {
-          name: 'Earlier date returns -1',
-          date1: new Date('2024-01-01T00:00:00.000Z'),
-          date2: new Date('2024-01-02T00:00:00.000Z'),
-          order: 'ASC' as const,
+          name: "Earlier date returns -1",
+          date1: new Date("2024-01-01T00:00:00.000Z"),
+          date2: new Date("2024-01-02T00:00:00.000Z"),
+          order: "ASC" as const,
           expected: -1,
         },
         {
-          name: 'Later date returns 1',
-          date1: new Date('2024-01-02T00:00:00.000Z'),
-          date2: new Date('2024-01-01T00:00:00.000Z'),
-          order: 'ASC' as const,
+          name: "Later date returns 1",
+          date1: new Date("2024-01-02T00:00:00.000Z"),
+          date2: new Date("2024-01-01T00:00:00.000Z"),
+          order: "ASC" as const,
           expected: 1,
         },
         {
-          name: 'Equal dates return 0',
-          date1: new Date('2024-01-01T00:00:00.000Z'),
-          date2: new Date('2024-01-01T00:00:00.000Z'),
-          order: 'ASC' as const,
+          name: "Equal dates return 0",
+          date1: new Date("2024-01-01T00:00:00.000Z"),
+          date2: new Date("2024-01-01T00:00:00.000Z"),
+          order: "ASC" as const,
           expected: 0,
         },
-      ])('should handle $name in ASC order', ({ date1, date2, order, expected }) => {
+      ])(
+        "should handle $name in ASC order",
+        ({ date1, date2, order, expected }) => {
+          const result = compare(date1, date2, order);
+          expect(result).toBe(expected);
+        },
+      );
+    });
+
+    describe("Descending order", () => {
+      it.each([
+        {
+          name: "Earlier date returns 1 in DESC mode",
+          date1: new Date("2024-01-01T00:00:00.000Z"),
+          date2: new Date("2024-01-02T00:00:00.000Z"),
+          order: "DESC" as const,
+          expected: 1,
+        },
+        {
+          name: "Later date returns -1 in DESC mode",
+          date1: new Date("2024-01-02T00:00:00.000Z"),
+          date2: new Date("2024-01-01T00:00:00.000Z"),
+          order: "DESC" as const,
+          expected: -1,
+        },
+        {
+          name: "Equal dates return 0 in DESC mode",
+          date1: new Date("2024-01-01T00:00:00.000Z"),
+          date2: new Date("2024-01-01T00:00:00.000Z"),
+          order: "DESC" as const,
+          expected: 0,
+        },
+      ])("should handle $name", ({ date1, date2, order, expected }) => {
         const result = compare(date1, date2, order);
         expect(result).toBe(expected);
       });
     });
 
-    describe('Descending order', () => {
-      it.each([
-        {
-          name: 'Earlier date returns 1 in DESC mode',
-          date1: new Date('2024-01-01T00:00:00.000Z'),
-          date2: new Date('2024-01-02T00:00:00.000Z'),
-          order: 'DESC' as const,
-          expected: 1,
-        },
-        {
-          name: 'Later date returns -1 in DESC mode',
-          date1: new Date('2024-01-02T00:00:00.000Z'),
-          date2: new Date('2024-01-01T00:00:00.000Z'),
-          order: 'DESC' as const,
-          expected: -1,
-        },
-        {
-          name: 'Equal dates return 0 in DESC mode',
-          date1: new Date('2024-01-01T00:00:00.000Z'),
-          date2: new Date('2024-01-01T00:00:00.000Z'),
-          order: 'DESC' as const,
-          expected: 0,
-        },
-      ])('should handle $name', ({ date1, date2, order, expected }) => {
-        const result = compare(date1, date2, order);
-        expect(result).toBe(expected);
-      });
-    });
-
-    describe('Default behavior', () => {
-      it('should default to ascending order when order parameter is omitted', () => {
-        const date1 = new Date('2024-01-01T00:00:00.000Z');
-        const date2 = new Date('2024-01-02T00:00:00.000Z');
+    describe("Default behavior", () => {
+      it("should default to ascending order when order parameter is omitted", () => {
+        const date1 = new Date("2024-01-01T00:00:00.000Z");
+        const date2 = new Date("2024-01-02T00:00:00.000Z");
 
         expect(compare(date1, date2)).toBe(-1);
       });
 
-      it('should default to ascending order when undefined is passed explicitly', () => {
-        const date1 = new Date('2024-01-01T00:00:00.000Z');
-        const date2 = new Date('2024-01-02T00:00:00.000Z');
+      it("should default to ascending order when undefined is passed explicitly", () => {
+        const date1 = new Date("2024-01-01T00:00:00.000Z");
+        const date2 = new Date("2024-01-02T00:00:00.000Z");
 
         expect(compare(date1, date2, undefined)).toBe(-1);
       });
@@ -80,90 +83,90 @@ describe('compare', () => {
   });
 
   // T004: Basic comparison scenarios
-  describe('Basic comparison scenarios', () => {
+  describe("Basic comparison scenarios", () => {
     it.each([
       {
-        name: 'Compare dates with different years',
-        date1: new Date('2023-12-31'),
-        date2: new Date('2024-01-01'),
+        name: "Compare dates with different years",
+        date1: new Date("2023-12-31"),
+        date2: new Date("2024-01-01"),
         expected: -1,
       },
       {
-        name: 'Compare dates with different months',
-        date1: new Date('2024-01-15'),
-        date2: new Date('2024-02-15'),
+        name: "Compare dates with different months",
+        date1: new Date("2024-01-15"),
+        date2: new Date("2024-02-15"),
         expected: -1,
       },
       {
-        name: 'Compare dates with different days',
-        date1: new Date('2024-01-15'),
-        date2: new Date('2024-01-16'),
+        name: "Compare dates with different days",
+        date1: new Date("2024-01-15"),
+        date2: new Date("2024-01-16"),
         expected: -1,
       },
       {
-        name: 'Compare dates with different hours',
-        date1: new Date('2024-01-01T10:00:00'),
-        date2: new Date('2024-01-01T11:00:00'),
+        name: "Compare dates with different hours",
+        date1: new Date("2024-01-01T10:00:00"),
+        date2: new Date("2024-01-01T11:00:00"),
         expected: -1,
       },
       {
-        name: 'Compare dates with millisecond precision',
-        date1: new Date('2024-01-01T12:00:00.001Z'),
-        date2: new Date('2024-01-01T12:00:00.002Z'),
+        name: "Compare dates with millisecond precision",
+        date1: new Date("2024-01-01T12:00:00.001Z"),
+        date2: new Date("2024-01-01T12:00:00.002Z"),
         expected: -1,
       },
-    ])('should correctly compare $name', ({ date1, date2, expected }) => {
+    ])("should correctly compare $name", ({ date1, date2, expected }) => {
       expect(compare(date1, date2)).toBe(expected);
       expect(compare(date2, date1)).toBe(-expected);
     });
 
-    describe('Descending order scenarios', () => {
-      it('should reverse comparison results for DESC order', () => {
-        const earlier = new Date('2024-01-01');
-        const later = new Date('2024-01-02');
+    describe("Descending order scenarios", () => {
+      it("should reverse comparison results for DESC order", () => {
+        const earlier = new Date("2024-01-01");
+        const later = new Date("2024-01-02");
 
-        expect(compare(earlier, later, 'ASC')).toBe(-1);
-        expect(compare(earlier, later, 'DESC')).toBe(1);
-        expect(compare(later, earlier, 'ASC')).toBe(1);
-        expect(compare(later, earlier, 'DESC')).toBe(-1);
+        expect(compare(earlier, later, "ASC")).toBe(-1);
+        expect(compare(earlier, later, "DESC")).toBe(1);
+        expect(compare(later, earlier, "ASC")).toBe(1);
+        expect(compare(later, earlier, "DESC")).toBe(-1);
       });
     });
   });
 
   // T005: Array.sort() integration tests
-  describe('Array.sort() integration', () => {
-    it('should sort dates in ascending order', () => {
+  describe("Array.sort() integration", () => {
+    it("should sort dates in ascending order", () => {
       const dates = [
-        new Date('2024-01-03'),
-        new Date('2024-01-01'),
-        new Date('2024-01-02'),
+        new Date("2024-01-03"),
+        new Date("2024-01-01"),
+        new Date("2024-01-02"),
       ];
 
       dates.sort(compare);
 
-      expect(dates[0].toISOString()).toBe('2024-01-01T00:00:00.000Z');
-      expect(dates[1].toISOString()).toBe('2024-01-02T00:00:00.000Z');
-      expect(dates[2].toISOString()).toBe('2024-01-03T00:00:00.000Z');
+      expect(dates[0].toISOString()).toBe("2024-01-01T00:00:00.000Z");
+      expect(dates[1].toISOString()).toBe("2024-01-02T00:00:00.000Z");
+      expect(dates[2].toISOString()).toBe("2024-01-03T00:00:00.000Z");
     });
 
-    it('should sort dates in descending order', () => {
+    it("should sort dates in descending order", () => {
       const dates = [
-        new Date('2024-01-01'),
-        new Date('2024-01-03'),
-        new Date('2024-01-02'),
+        new Date("2024-01-01"),
+        new Date("2024-01-03"),
+        new Date("2024-01-02"),
       ];
 
-      dates.sort((a, b) => compare(a, b, 'DESC'));
+      dates.sort((a, b) => compare(a, b, "DESC"));
 
-      expect(dates[0].toISOString()).toBe('2024-01-03T00:00:00.000Z');
-      expect(dates[1].toISOString()).toBe('2024-01-02T00:00:00.000Z');
-      expect(dates[2].toISOString()).toBe('2024-01-01T00:00:00.000Z');
+      expect(dates[0].toISOString()).toBe("2024-01-03T00:00:00.000Z");
+      expect(dates[1].toISOString()).toBe("2024-01-02T00:00:00.000Z");
+      expect(dates[2].toISOString()).toBe("2024-01-01T00:00:00.000Z");
     });
 
-    it('should maintain sort stability for equal dates', () => {
-      const date1 = new Date('2024-01-01T00:00:00.000Z');
-      const date2 = new Date('2024-01-01T00:00:00.000Z');
-      const date3 = new Date('2024-01-02T00:00:00.000Z');
+    it("should maintain sort stability for equal dates", () => {
+      const date1 = new Date("2024-01-01T00:00:00.000Z");
+      const date2 = new Date("2024-01-01T00:00:00.000Z");
+      const date3 = new Date("2024-01-02T00:00:00.000Z");
 
       const dates = [date3, date1, date2];
       dates.sort(compare);
@@ -172,9 +175,10 @@ describe('compare', () => {
       expect(dates[2]).toBe(date3); // Last should be the later date
     });
 
-    it('should work with large date arrays', () => {
-      const dates = Array.from({ length: 100 }, (_, i) =>
-        new Date(2024, 0, Math.floor(Math.random() * 31) + 1)
+    it("should work with large date arrays", () => {
+      const dates = Array.from(
+        { length: 100 },
+        (_, i) => new Date(2024, 0, Math.floor(Math.random() * 31) + 1),
       );
       const originalDates = [...dates];
 
@@ -182,7 +186,7 @@ describe('compare', () => {
 
       // Verify sorting is correct
       for (let i = 1; i < dates.length; i++) {
-        expect(compare(dates[i-1], dates[i])).toBeLessThanOrEqual(0);
+        expect(compare(dates[i - 1], dates[i])).toBeLessThanOrEqual(0);
       }
 
       // Verify all original dates are still present
@@ -191,89 +195,75 @@ describe('compare', () => {
   });
 
   // T006: Error handling tests for invalid arguments
-  describe('Error handling', () => {
-    describe('Invalid first argument', () => {
+  describe("Error handling", () => {
+    describe("Invalid first argument", () => {
       it.each([
-        { name: 'null', input: null },
-        { name: 'undefined', input: undefined },
-        { name: 'string', input: '2024-01-01' },
-        { name: 'boolean', input: true },
-        { name: 'object', input: {} },
-        { name: 'array', input: [] },
-      ])('should throw RangeError for $name as first argument', ({ input }) => {
-        expect(() => {
-          compare(input as any, new Date());
-        }).toThrow(RangeError);
-        expect(() => {
-          compare(input as any, new Date());
-        }).toThrow('First argument must be a Date object');
+        { name: "null", input: null },
+        { name: "undefined", input: undefined },
+        { name: "string", input: "2024-01-01" },
+        { name: "boolean", input: true },
+        { name: "object", input: {} },
+        { name: "array", input: [] },
+      ])("should return NaN for $name as first argument", ({ input }) => {
+        const result = compare(input as any, new Date());
+        expect(result).toBeNaN();
       });
 
-      it('should accept number as first argument (new feature)', () => {
+      it("should accept number as first argument (new feature)", () => {
         const timestamp = 1704067200000; // Valid timestamp
-        const date = new Date('2024-01-02');
+        const date = new Date("2024-01-02");
 
-        expect(() => compare(timestamp, date)).not.toThrow();
+        expect(() => compare(timestamp, date)).not.toBeNaN();
         expect(compare(timestamp, date)).toBe(-1); // timestamp is earlier
       });
     });
 
-    describe('Invalid second argument', () => {
+    describe("Invalid second argument", () => {
       it.each([
-        { name: 'null', input: null },
-        { name: 'undefined', input: undefined },
-        { name: 'string', input: '2024-01-01' },
-        { name: 'boolean', input: true },
-        { name: 'object', input: {} },
-        { name: 'array', input: [] },
-      ])('should throw RangeError for $name as second argument', ({ input }) => {
-        expect(() => {
-          compare(new Date(), input as any);
-        }).toThrow(RangeError);
-        expect(() => {
-          compare(new Date(), input as any);
-        }).toThrow('Second argument must be a Date object');
+        { name: "null", input: null },
+        { name: "undefined", input: undefined },
+        { name: "string", input: "2024-01-01" },
+        { name: "boolean", input: true },
+        { name: "object", input: {} },
+        { name: "array", input: [] },
+      ])("should return NaN for $name as second argument", ({ input }) => {
+        const result = compare(new Date(), input as any);
+        expect(result).toBeNaN();
       });
 
-      it('should accept number as second argument (new feature)', () => {
-        const date = new Date('2024-01-01');
+      it("should accept number as second argument (new feature)", () => {
+        const date = new Date("2024-01-01");
         const timestamp = 1704153600000; // Valid timestamp for later date
 
-        expect(() => compare(date, timestamp)).not.toThrow();
+        expect(() => compare(date, timestamp)).not.toBeNaN();
         expect(compare(date, timestamp)).toBe(-1); // date is earlier than timestamp
       });
     });
 
-    describe('Invalid Date objects', () => {
-      it('should throw RangeError for invalid first date', () => {
-        const invalidDate = new Date('invalid');
+    describe("Invalid Date objects", () => {
+      it("should return NaN for invalid first date", () => {
+        const invalidDate = new Date("invalid");
         const validDate = new Date();
 
-        expect(() => {
-          compare(invalidDate, validDate);
-        }).toThrow(RangeError);
-        expect(() => {
-          compare(invalidDate, validDate);
-        }).toThrow('First date is invalid');
+        const result = compare(invalidDate, validDate);
+
+        expect(result).toBeNaN();
       });
 
-      it('should throw RangeError for invalid second date', () => {
+      it("should return NaN for invalid second date", () => {
         const validDate = new Date();
-        const invalidDate = new Date('invalid');
+        const invalidDate = new Date("invalid");
 
-        expect(() => {
-          compare(validDate, invalidDate);
-        }).toThrow(RangeError);
-        expect(() => {
-          compare(validDate, invalidDate);
-        }).toThrow('Second date is invalid');
+        const result = compare(validDate, invalidDate);
+
+        expect(result).toBeNaN();
       });
     });
 
-    describe('Order parameter behavior (new specification)', () => {
-      it('should handle null and undefined order parameters without throwing', () => {
-        const date1 = new Date('2024-01-01');
-        const date2 = new Date('2024-01-02');
+    describe("Order parameter behavior (new specification)", () => {
+      it("should handle null and undefined order parameters without throwing", () => {
+        const date1 = new Date("2024-01-01");
+        const date2 = new Date("2024-01-02");
 
         // Test that null doesn't cause toUpperCase() error
         // @ts-expect-error Testing runtime behavior with null
@@ -291,44 +281,44 @@ describe('compare', () => {
         expect(compare(date1, date2, undefined)).toBe(compare(date1, date2));
       });
 
-      it('should accept case-insensitive order parameters', () => {
-        const date1 = new Date('2024-01-01');
-        const date2 = new Date('2024-01-02');
+      it("should accept case-insensitive order parameters", () => {
+        const date1 = new Date("2024-01-01");
+        const date2 = new Date("2024-01-02");
 
         // Test case-insensitive order parameters
         // @ts-expect-error Testing runtime behavior with non-typed values
-        expect(compare(date1, date2, 'asc')).toBe(-1);
+        expect(compare(date1, date2, "asc")).toBe(-1);
         // @ts-expect-error Testing runtime behavior with non-typed values
-        expect(compare(date1, date2, 'Asc')).toBe(-1);
+        expect(compare(date1, date2, "Asc")).toBe(-1);
         // @ts-expect-error Testing runtime behavior with non-typed values
-        expect(compare(date1, date2, 'ASC')).toBe(-1);
+        expect(compare(date1, date2, "ASC")).toBe(-1);
 
         // @ts-expect-error Testing runtime behavior with non-typed values
-        expect(compare(date1, date2, 'desc')).toBe(1);
+        expect(compare(date1, date2, "desc")).toBe(1);
         // @ts-expect-error Testing runtime behavior with non-typed values
-        expect(compare(date1, date2, 'Desc')).toBe(1);
+        expect(compare(date1, date2, "Desc")).toBe(1);
         // @ts-expect-error Testing runtime behavior with non-typed values
-        expect(compare(date1, date2, 'DESC')).toBe(1);
+        expect(compare(date1, date2, "DESC")).toBe(1);
       });
 
-      it('should treat invalid strings as ASC (default)', () => {
-        const date1 = new Date('2024-01-01');
-        const date2 = new Date('2024-01-02');
+      it("should treat invalid strings as ASC (default)", () => {
+        const date1 = new Date("2024-01-01");
+        const date2 = new Date("2024-01-02");
 
         // Invalid strings should default to ASC
         // @ts-expect-error Testing runtime behavior with invalid values
-        expect(compare(date1, date2, 'ASCENDING')).toBe(-1);
+        expect(compare(date1, date2, "ASCENDING")).toBe(-1);
         // @ts-expect-error Testing runtime behavior with invalid values
-        expect(compare(date1, date2, 'DESCENDING')).toBe(-1);
+        expect(compare(date1, date2, "DESCENDING")).toBe(-1);
         // @ts-expect-error Testing runtime behavior with invalid values
-        expect(compare(date1, date2, 'xyz')).toBe(-1);
+        expect(compare(date1, date2, "xyz")).toBe(-1);
         // @ts-expect-error Testing runtime behavior with invalid values
-        expect(compare(date1, date2, '')).toBe(-1);
+        expect(compare(date1, date2, "")).toBe(-1);
       });
 
-      it('should treat non-string values as ASC (default)', () => {
-        const date1 = new Date('2024-01-01');
-        const date2 = new Date('2024-01-02');
+      it("should treat non-string values as ASC (default)", () => {
+        const date1 = new Date("2024-01-01");
+        const date2 = new Date("2024-01-02");
 
         // Non-string values should default to ASC
         // @ts-expect-error Testing runtime behavior with invalid values
@@ -352,29 +342,29 @@ describe('compare', () => {
   });
 
   // T007: Edge case tests for date boundaries and precision
-  describe('Edge cases', () => {
-    describe('Date boundaries', () => {
-      it('should handle maximum valid Date timestamp', () => {
+  describe("Edge cases", () => {
+    describe("Date boundaries", () => {
+      it("should handle maximum valid Date timestamp", () => {
         const maxDate = new Date(8640000000000000);
-        const normalDate = new Date('2024-01-01');
+        const normalDate = new Date("2024-01-01");
 
         expect(compare(normalDate, maxDate)).toBe(-1);
         expect(compare(maxDate, normalDate)).toBe(1);
         expect(compare(maxDate, maxDate)).toBe(0);
       });
 
-      it('should handle minimum valid Date timestamp', () => {
+      it("should handle minimum valid Date timestamp", () => {
         const minDate = new Date(-8640000000000000);
-        const normalDate = new Date('2024-01-01');
+        const normalDate = new Date("2024-01-01");
 
         expect(compare(minDate, normalDate)).toBe(-1);
         expect(compare(normalDate, minDate)).toBe(1);
         expect(compare(minDate, minDate)).toBe(0);
       });
 
-      it('should handle Unix epoch', () => {
+      it("should handle Unix epoch", () => {
         const epochDate = new Date(0);
-        const laterDate = new Date('2024-01-01');
+        const laterDate = new Date("2024-01-01");
 
         expect(compare(epochDate, laterDate)).toBe(-1);
         expect(compare(laterDate, epochDate)).toBe(1);
@@ -382,17 +372,17 @@ describe('compare', () => {
       });
     });
 
-    describe('Precision handling', () => {
-      it('should handle millisecond precision differences', () => {
-        const date1 = new Date('2024-01-01T12:00:00.001Z');
-        const date2 = new Date('2024-01-01T12:00:00.002Z');
+    describe("Precision handling", () => {
+      it("should handle millisecond precision differences", () => {
+        const date1 = new Date("2024-01-01T12:00:00.001Z");
+        const date2 = new Date("2024-01-01T12:00:00.002Z");
 
         expect(compare(date1, date2)).toBe(-1);
         expect(compare(date2, date1)).toBe(1);
       });
 
-      it('should handle identical timestamps created differently', () => {
-        const date1 = new Date('2024-01-01T00:00:00.000Z');
+      it("should handle identical timestamps created differently", () => {
+        const date1 = new Date("2024-01-01T00:00:00.000Z");
         const date2 = new Date(2024, 0, 1, 0, 0, 0, 0);
 
         // Adjust for timezone if needed
@@ -402,10 +392,10 @@ describe('compare', () => {
       });
     });
 
-    describe('Timezone consistency', () => {
-      it('should compare dates consistently regardless of timezone representation', () => {
+    describe("Timezone consistency", () => {
+      it("should compare dates consistently regardless of timezone representation", () => {
         // Same moment in time, different timezone representations
-        const utcDate = new Date('2024-01-01T12:00:00.000Z');
+        const utcDate = new Date("2024-01-01T12:00:00.000Z");
         const localDate = new Date(utcDate.getTime());
 
         expect(compare(utcDate, localDate)).toBe(0);
@@ -414,10 +404,11 @@ describe('compare', () => {
   });
 
   // T008: Performance comparison tests vs native Date comparison
-  describe.skip('Performance tests', () => {
-    it('should perform comparably to direct Date comparison', () => {
-      const dates1 = Array.from({ length: 1000 }, () =>
-        new Date(Math.random() * 1000000000000)
+  describe.skip("Performance tests", () => {
+    it("should perform comparably to direct Date comparison", () => {
+      const dates1 = Array.from(
+        { length: 1000 },
+        () => new Date(Math.random() * 1000000000000),
       );
       const dates2 = [...dates1];
 
@@ -435,9 +426,9 @@ describe('compare', () => {
       expect(compareTime).toBeLessThan(nativeTime * 10);
     });
 
-    it('should handle rapid successive comparisons efficiently', () => {
-      const date1 = new Date('2024-01-01');
-      const date2 = new Date('2024-01-02');
+    it("should handle rapid successive comparisons efficiently", () => {
+      const date1 = new Date("2024-01-01");
+      const date2 = new Date("2024-01-02");
 
       const startTime = performance.now();
 
@@ -457,12 +448,12 @@ describe('compare', () => {
   });
 
   // T009: Compatibility tests verifying correct -1/0/1 return values for Array.sort()
-  describe('Array.sort() compatibility', () => {
-    it('should return only -1, 0, or 1', () => {
+  describe("Array.sort() compatibility", () => {
+    it("should return only -1, 0, or 1", () => {
       const testCases = [
-        [new Date('2024-01-01'), new Date('2024-01-02')], // -1
-        [new Date('2024-01-02'), new Date('2024-01-01')], // 1
-        [new Date('2024-01-01'), new Date('2024-01-01')], // 0
+        [new Date("2024-01-01"), new Date("2024-01-02")], // -1
+        [new Date("2024-01-02"), new Date("2024-01-01")], // 1
+        [new Date("2024-01-01"), new Date("2024-01-01")], // 0
         [new Date(0), new Date(1000)], // -1
         [new Date(8640000000000000), new Date(-8640000000000000)], // 1
       ];
@@ -473,10 +464,10 @@ describe('compare', () => {
       });
     });
 
-    it('should satisfy transitivity property for sorting', () => {
-      const a = new Date('2024-01-01');
-      const b = new Date('2024-01-02');
-      const c = new Date('2024-01-03');
+    it("should satisfy transitivity property for sorting", () => {
+      const a = new Date("2024-01-01");
+      const b = new Date("2024-01-02");
+      const c = new Date("2024-01-03");
 
       // If a < b and b < c, then a < c
       expect(compare(a, b)).toBe(-1);
@@ -484,9 +475,9 @@ describe('compare', () => {
       expect(compare(a, c)).toBe(-1);
     });
 
-    it('should satisfy antisymmetry property', () => {
-      const date1 = new Date('2024-01-01');
-      const date2 = new Date('2024-01-02');
+    it("should satisfy antisymmetry property", () => {
+      const date1 = new Date("2024-01-01");
+      const date2 = new Date("2024-01-02");
 
       // If compare(a,b) = x, then compare(b,a) = -x (except when x = 0)
       const result1 = compare(date1, date2);
@@ -499,21 +490,21 @@ describe('compare', () => {
       }
     });
 
-    it('should satisfy reflexivity property', () => {
-      const date = new Date('2024-01-01');
+    it("should satisfy reflexivity property", () => {
+      const date = new Date("2024-01-01");
 
       // compare(a, a) should always be 0
       expect(compare(date, date)).toBe(0);
     });
 
-    it('should work correctly with Array.sort() for various scenarios', () => {
+    it("should work correctly with Array.sort() for various scenarios", () => {
       // Test with duplicate dates
       const dates = [
-        new Date('2024-01-03'),
-        new Date('2024-01-01'),
-        new Date('2024-01-02'),
-        new Date('2024-01-01'), // duplicate
-        new Date('2024-01-03'), // duplicate
+        new Date("2024-01-03"),
+        new Date("2024-01-01"),
+        new Date("2024-01-02"),
+        new Date("2024-01-01"), // duplicate
+        new Date("2024-01-03"), // duplicate
       ];
 
       dates.sort(compare);
@@ -526,3 +517,4 @@ describe('compare', () => {
     });
   });
 });
+

--- a/tests/enhanced-compare-compatibility.test.ts
+++ b/tests/enhanced-compare-compatibility.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect } from 'vitest';
-import { compare } from '../src/compare/index.js';
+import { describe, it, expect } from "vitest";
+import { compare } from "../src/compare/index.js";
 
-describe('Enhanced Compare Backward Compatibility Tests', () => {
-  describe('Existing Function Signature Compatibility', () => {
-    it('should maintain identical behavior for Date objects', () => {
-      const date1 = new Date('2024-01-01');
-      const date2 = new Date('2024-01-02');
-      const date3 = new Date('2024-01-01'); // Equal to date1
+describe("Enhanced Compare Backward Compatibility Tests", () => {
+  describe("Existing Function Signature Compatibility", () => {
+    it("should maintain identical behavior for Date objects", () => {
+      const date1 = new Date("2024-01-01");
+      const date2 = new Date("2024-01-02");
+      const date3 = new Date("2024-01-01"); // Equal to date1
 
       // Basic comparisons
       expect(compare(date1, date2)).toBe(-1);
@@ -14,68 +14,72 @@ describe('Enhanced Compare Backward Compatibility Tests', () => {
       expect(compare(date1, date3)).toBe(0);
 
       // With explicit ASC order
-      expect(compare(date1, date2, 'ASC')).toBe(-1);
-      expect(compare(date2, date1, 'ASC')).toBe(1);
-      expect(compare(date1, date3, 'ASC')).toBe(0);
+      expect(compare(date1, date2, "ASC")).toBe(-1);
+      expect(compare(date2, date1, "ASC")).toBe(1);
+      expect(compare(date1, date3, "ASC")).toBe(0);
 
       // With DESC order
-      expect(compare(date1, date2, 'DESC')).toBe(1);
-      expect(compare(date2, date1, 'DESC')).toBe(-1);
-      expect(compare(date1, date3, 'DESC')).toBe(0);
+      expect(compare(date1, date2, "DESC")).toBe(1);
+      expect(compare(date2, date1, "DESC")).toBe(-1);
+      expect(compare(date1, date3, "DESC")).toBe(0);
     });
 
-    it('should maintain Array.sort() compatibility', () => {
+    it("should maintain Array.sort() compatibility", () => {
       const dates = [
-        new Date('2024-01-03'),
-        new Date('2024-01-01'),
-        new Date('2024-01-02')
+        new Date("2024-01-03"),
+        new Date("2024-01-01"),
+        new Date("2024-01-02"),
       ];
 
       // Ascending sort
       const ascSorted = [...dates].sort(compare);
-      expect(ascSorted[0].getTime()).toBe(new Date('2024-01-01').getTime());
-      expect(ascSorted[1].getTime()).toBe(new Date('2024-01-02').getTime());
-      expect(ascSorted[2].getTime()).toBe(new Date('2024-01-03').getTime());
+      expect(ascSorted[0].getTime()).toBe(new Date("2024-01-01").getTime());
+      expect(ascSorted[1].getTime()).toBe(new Date("2024-01-02").getTime());
+      expect(ascSorted[2].getTime()).toBe(new Date("2024-01-03").getTime());
 
       // Descending sort
-      const descSorted = [...dates].sort((a, b) => compare(a, b, 'DESC'));
-      expect(descSorted[0].getTime()).toBe(new Date('2024-01-03').getTime());
-      expect(descSorted[1].getTime()).toBe(new Date('2024-01-02').getTime());
-      expect(descSorted[2].getTime()).toBe(new Date('2024-01-01').getTime());
+      const descSorted = [...dates].sort((a, b) => compare(a, b, "DESC"));
+      expect(descSorted[0].getTime()).toBe(new Date("2024-01-03").getTime());
+      expect(descSorted[1].getTime()).toBe(new Date("2024-01-02").getTime());
+      expect(descSorted[2].getTime()).toBe(new Date("2024-01-01").getTime());
     });
 
-    it('should maintain error handling for invalid Date objects', () => {
-      const invalidDate = new Date('invalid');
-      const validDate = new Date('2024-01-01');
+    it("should maintain error handling for invalid Date objects", () => {
+      const invalidDate = new Date("invalid");
+      const validDate = new Date("2024-01-01");
 
-      expect(() => compare(invalidDate, validDate)).toThrow(RangeError);
-      expect(() => compare(validDate, invalidDate)).toThrow(RangeError);
-      expect(() => compare(invalidDate, invalidDate)).toThrow(RangeError);
+      const result1 = compare(invalidDate, validDate);
+      const result2 = compare(validDate, invalidDate);
+      const result3 = compare(invalidDate, invalidDate);
+
+      expect(result1).toBeNaN();
+      expect(result2).toBeNaN();
+      expect(result3).toBeNaN();
     });
 
-    it('should handle runtime order parameters with new specification', () => {
-      const date1 = new Date('2024-01-01');
-      const date2 = new Date('2024-01-02');
+    it("should handle runtime order parameters with new specification", () => {
+      const date1 = new Date("2024-01-01");
+      const date2 = new Date("2024-01-02");
 
       // New behavior: invalid order parameters default to ASC (no errors)
       // @ts-expect-error Testing runtime behavior
-      expect(() => compare(date1, date2, 'invalid')).not.toThrow();
+      expect(() => compare(date1, date2, "invalid")).not.toThrow();
       // @ts-expect-error Testing runtime behavior
-      expect(compare(date1, date2, 'invalid')).toBe(-1); // defaults to ASC
+      expect(compare(date1, date2, "invalid")).toBe(-1); // defaults to ASC
 
       // Case-insensitive handling
       // @ts-expect-error Testing runtime behavior
-      expect(compare(date1, date2, 'asc')).toBe(-1);
+      expect(compare(date1, date2, "asc")).toBe(-1);
       // @ts-expect-error Testing runtime behavior
-      expect(compare(date1, date2, 'desc')).toBe(1);
+      expect(compare(date1, date2, "desc")).toBe(1);
     });
   });
 
-  describe('Edge Cases Compatibility', () => {
-    it('should handle boundary dates correctly', () => {
+  describe("Edge Cases Compatibility", () => {
+    it("should handle boundary dates correctly", () => {
       const minDate = new Date(-8640000000000000);
       const maxDate = new Date(8640000000000000);
-      const normalDate = new Date('2024-01-01');
+      const normalDate = new Date("2024-01-01");
 
       expect(compare(minDate, maxDate)).toBe(-1);
       expect(compare(maxDate, minDate)).toBe(1);
@@ -83,30 +87,31 @@ describe('Enhanced Compare Backward Compatibility Tests', () => {
       expect(compare(normalDate, maxDate)).toBe(-1);
     });
 
-    it('should handle millisecond precision correctly', () => {
-      const date1 = new Date('2024-01-01T00:00:00.000Z');
-      const date2 = new Date('2024-01-01T00:00:00.001Z');
+    it("should handle millisecond precision correctly", () => {
+      const date1 = new Date("2024-01-01T00:00:00.000Z");
+      const date2 = new Date("2024-01-01T00:00:00.001Z");
 
       expect(compare(date1, date2)).toBe(-1);
       expect(compare(date2, date1)).toBe(1);
       expect(compare(date1, date1)).toBe(0);
     });
 
-    it('should handle timezone consistency', () => {
+    it("should handle timezone consistency", () => {
       // Dates that represent the same moment but created differently
-      const utcDate = new Date('2024-01-01T12:00:00.000Z');
+      const utcDate = new Date("2024-01-01T12:00:00.000Z");
       const localDate = new Date(2024, 0, 1, 12, 0, 0, 0); // Local time
 
       // Since compare uses getTime(), timezone representation shouldn't matter
       // for the comparison logic itself
       expect(() => compare(utcDate, localDate)).not.toThrow();
-      expect(typeof compare(utcDate, localDate)).toBe('number');
+      expect(typeof compare(utcDate, localDate)).toBe("number");
     });
 
-    it('should maintain performance characteristics', () => {
+    it("should maintain performance characteristics", () => {
       // Test that existing performance is not degraded
-      const dates = Array.from({ length: 1000 }, () =>
-        new Date(Date.now() - Math.random() * 365 * 24 * 60 * 60 * 1000)
+      const dates = Array.from(
+        { length: 1000 },
+        () => new Date(Date.now() - Math.random() * 365 * 24 * 60 * 60 * 1000),
       );
 
       const start = performance.now();
@@ -118,30 +123,31 @@ describe('Enhanced Compare Backward Compatibility Tests', () => {
     });
   });
 
-  describe('Type System Compatibility', () => {
-    it('should accept existing function call patterns', () => {
-      const date1 = new Date('2024-01-01');
-      const date2 = new Date('2024-01-02');
+  describe("Type System Compatibility", () => {
+    it("should accept existing function call patterns", () => {
+      const date1 = new Date("2024-01-01");
+      const date2 = new Date("2024-01-02");
 
       // All these should work without TypeScript errors
       expect(() => compare(date1, date2)).not.toThrow();
-      expect(() => compare(date1, date2, 'ASC')).not.toThrow();
-      expect(() => compare(date1, date2, 'DESC')).not.toThrow();
+      expect(() => compare(date1, date2, "ASC")).not.toThrow();
+      expect(() => compare(date1, date2, "DESC")).not.toThrow();
     });
 
-    it('should return correct numeric values', () => {
-      const date1 = new Date('2024-01-01');
-      const date2 = new Date('2024-01-02');
+    it("should return correct numeric values", () => {
+      const date1 = new Date("2024-01-01");
+      const date2 = new Date("2024-01-02");
 
       const result1 = compare(date1, date2);
       const result2 = compare(date2, date1);
       const result3 = compare(date1, date1);
 
-      expect(typeof result1).toBe('number');
-      expect(typeof result2).toBe('number');
-      expect(typeof result3).toBe('number');
+      expect(typeof result1).toBe("number");
+      expect(typeof result2).toBe("number");
+      expect(typeof result3).toBe("number");
 
       expect([result1, result2, result3]).toEqual([-1, 1, 0]);
     });
   });
 });
+

--- a/tests/max.test.ts
+++ b/tests/max.test.ts
@@ -45,7 +45,7 @@ describe("max", () => {
     expect(result.getTime()).toBe(timestamp);
   });
 
-  it("throws error when called with no arguments", () => {
+  it("returns NaN when called with no arguments", () => {
     const result = max();
     expect(result.getTime()).toBeNaN();
   });

--- a/tests/max.test.ts
+++ b/tests/max.test.ts
@@ -46,7 +46,8 @@ describe("max", () => {
   });
 
   it("throws error when called with no arguments", () => {
-    expect(() => max()).toThrow("max requires at least one date argument");
+    const result = max();
+    expect(result.getTime()).toBeNaN();
   });
 
   it("returns Invalid Date when any input is invalid", () => {
@@ -159,3 +160,4 @@ describe("max", () => {
     expect(result instanceof Date).toBe(true);
   });
 });
+

--- a/tests/min.test.ts
+++ b/tests/min.test.ts
@@ -45,7 +45,7 @@ describe("min", () => {
     expect(result.getTime()).toBe(timestamp);
   });
 
-  it("throws error when called with no arguments", () => {
+  it("returns NaN when called with no arguments", () => {
     const result = min();
     expect(result.getTime()).toBeNaN();
   });

--- a/tests/min.test.ts
+++ b/tests/min.test.ts
@@ -46,7 +46,8 @@ describe("min", () => {
   });
 
   it("throws error when called with no arguments", () => {
-    expect(() => min()).toThrow("min requires at least one date argument");
+    const result = min();
+    expect(result.getTime()).toBeNaN();
   });
 
   it("returns Invalid Date when any input is invalid", () => {
@@ -159,3 +160,4 @@ describe("min", () => {
     expect(result instanceof Date).toBe(true);
   });
 });
+


### PR DESCRIPTION
The min, max, and compare functions previously threw exceptions during validation. To align with the library's core policy, they have been modified to return Invalid Date or NaN instead.