### PR TITLE
fix: remove registry-url from publish workflow for Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22.x'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
## Summary

Trusted Publishingを使用する際に`registry-url`パラメータが認証プロセスと競合していたため削除しました。

## Problem

v0.1.12のリリース時に以下のエラーが発生していました:
```
npm error 404 Not Found - PUT https://registry.npmjs.org/chronia - Not found
```

## Root Cause

Trusted Publishing (OIDC認証) を使用している場合、`actions/setup-node`の`registry-url`パラメータは不要です。この設定により`.npmrc`が自動生成され、OIDC認証と競合する可能性があります。

## Solution

`registry-url: 'https://registry.npmjs.org'`の行を削除しました。

Trusted PublishingではOIDCトークンベースの認証が使用されるため、従来のregistry設定は不要です。

## Changes

- `.github/workflows/publish.yml`: `registry-url`パラメータを削除

## Testing

このPRをマージ後、以下の手順でテストできます:
1. GitHub Actionsで失敗したpublishワークフローを再実行
2. npmへの公開が正常に完了することを確認

## References

- [npm Trusted Publishing documentation](https://docs.npmjs.com/generating-provenance-statements)
- [GitHub Actions OIDC documentation](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for package publishing.

**Note:** This is an internal infrastructure change with no direct impact to end-user functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->