### PR TITLE
fix: update publish workflow for npm Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,10 @@ jobs:
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: '22.x'
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install
@@ -28,4 +29,4 @@ jobs:
         run: pnpm build
 
       - name: Publish to npm
-        run: pnpm publish --provenance --no-git-checks
+        run: pnpm publish --provenance --access public


### PR DESCRIPTION
## Summary

npm Trusted Publishingで公開できるようにワークフロー設定を更新しました。

## Changes

### 1. actions/setup-node を v5 に更新
- `actions/setup-node@v4` → `actions/setup-node@v5`
- 最新のNode.js設定とnpm認証処理に対応

### 2. Node.jsバージョンを24.xに更新
- `node-version: '22.x'` → `node-version: '24.x'`
- より新しいNode.jsバージョンでのビルドと公開

### 3. registry-url設定を追加
- `registry-url: 'https://registry.npmjs.org'`を追加
- npm認証に必要な設定

### 4. publishコマンドを更新
- `pnpm publish --provenance --no-git-checks`
- → `pnpm publish --provenance --access public`
- `--access public`フラグでパブリック公開を明示的に指定
- `--no-git-checks`を削除（不要なフラグ）

## Previous Error

v0.1.12のリリース時に以下のエラーが発生していました:
```
npm error 404 Not Found - PUT https://registry.npmjs.org/chronia - Not found
npm error 404  'chronia@0.1.12' is not in this registry.
```

## Testing Plan

このPRをマージ後:
1. GitHub Actionsで失敗したpublishワークフロー（v0.1.12）を再実行
2. npmへの公開が正常に完了することを確認
3. `pnpm view chronia@0.1.12`でバージョンが公開されたことを確認

## Related

- Closes #31 (previous attempt)
- Related to release v0.1.12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and publish tooling configurations to use latest Node.js and setup dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->