### PR TITLE
fix: add --no-git-checks flag to publish command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,4 +29,4 @@ jobs:
         run: pnpm build
 
       - name: Publish to npm
-        run: pnpm publish --provenance --access public
+        run: pnpm publish --provenance --access public --no-git-checks


### PR DESCRIPTION
## Summary

GitHub Actionsでのnpm公開時に必要な`--no-git-checks`フラグを追加しました。

## Problem

v0.1.12のリリース時に以下のエラーが発生しました:
```
ERR_PNPM_GIT_UNKNOWN_BRANCH  The Git HEAD may not attached to any branch, 
but your "publish-branch" is set to "master|main".
```

## Root Cause

GitHub Actionsでリリースタグをチェックアウトする際、GitのHEADが「detached HEAD」状態になります。この状態ではどのブランチにも属していないため、pnpmのデフォルトのGitブランチチェック（`main`または`master`ブランチにいることを確認）が失敗します。

## Solution

publishコマンドに`--no-git-checks`フラグを追加しました:
```bash
pnpm publish --provenance --access public --no-git-checks
```

このフラグにより、CI/CD環境でのGitブランチチェックをバイパスします。

## Changes

- `.github/workflows/publish.yml`: publishコマンドに`--no-git-checks`フラグを追加

## Testing Plan

このPRをマージ後:
1. v0.1.12のリリースとタグを削除して再作成
2. 新しいワークフローが自動実行される
3. npmへの公開が正常に完了することを確認

## Related

- Related to PR #32
- Fixes release v0.1.12 publish failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated publishing workflow configuration to modify Git verification behavior during releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->