### PR TITLE
docs: clarify Node.js version support (v18-v24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It offers a simple, consistent, and functional API that makes working with dates
 
 ## Installation
 
-Chronia requires **Node.js v18 or higher**.
+Chronia requires **Node.js v18 to v24**.
 
 ```bash
 # Using pnpm (recommended)

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,7 @@ Chronia is a modern, lightweight TypeScript date/time utility library with compr
 
 ## Installation
 
-Chronia requires **Node.js v18 or higher**.
+Chronia requires **Node.js v18 to v24**.
 
 ```bash
 # Using pnpm (recommended)


### PR DESCRIPTION
## Summary
- Update `README.md` to specify "v18 to v24" instead of "v18 or higher"
- Update `docs/README.md` with the same clarification
- CI already tests [18.x, 20.x, 22.x, 24.x] - no changes needed to CI configuration

## Test Plan
- [x] Verify documentation accurately reflects CI matrix
- [x] Ensure users understand the supported version range
- [x] Confirm CI matrix matches documented support ([18.x, 20.x, 22.x, 24.x])

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)