### PR TITLE
chore: add .serena to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ site/
 
 # Temporary files and test scripts
 .tmp/
+
+# Serena cache
+.serena/


### PR DESCRIPTION
## Summary
- Add `.serena/` to `.gitignore` to exclude Serena cache files from version control

## Test plan
- [x] Verify `.serena/` directory is no longer tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)