### PR TITLE
chore: optimize CI workflow and update Node.js support policy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     strategy:
       matrix:
@@ -31,9 +31,20 @@ jobs:
           cache: "pnpm"
 
       - run: sfw pnpm install
-      - run: pnpm lint
+
+      - name: Lint
+        if: matrix.node-version == '24.x'
+        run: pnpm lint
+
       - run: pnpm run build
-      - run: pnpm vitest run --coverage
+
+      - name: Test
+        if: matrix.node-version != '24.x'
+        run: pnpm vitest run
+
+      - name: Test with coverage
+        if: matrix.node-version == '24.x'
+        run: pnpm vitest run --coverage
 
       - name: Upload coverage reports to Codecov
         if: matrix.node-version == '24.x' && github.actor != 'dependabot[bot]'

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It offers a simple, consistent, and functional API that makes working with dates
 
 ## Installation
 
-Chronia requires **Node.js v18 to v24**.
+Chronia requires **Node.js v18 or higher**.
 
 ```bash
 # Using pnpm (recommended)
@@ -317,11 +317,11 @@ Use `isValid()` to distinguish these cases.
 
 ## Node.js Version Support Policy
 
-- Support is limited to **LTS releases (even-numbered major versions)** (e.g., v18, v20, v22, v24, ...).
+- Support includes **LTS releases (even-numbered major versions)** (e.g., v18, v20, v22, v24, ...) and **Current releases** that are actively maintained.
 - For LTS versions that have reached end-of-life (EOL), support will continue **as long as the following conditions are not met**:
   - Updates to dependencies become impossible
   - Changes in the Node.js core make it impossible to maintain compatibility
-- CI tests must include the latest LTS release, and older LTS releases will be tested as far as reasonably possible
+- CI tests include all supported LTS releases and the latest Node.js version (including Current releases when available)
 
 ## Versioning and Backward Compatibility Policy
 


### PR DESCRIPTION
## Summary

- Migrate CI runner from `ubuntu-latest` to `ubuntu-slim` for cost efficiency
- Run lint only on Node.js 24.x to reduce redundant checks
- Run coverage only on Node.js 24.x to optimize CI time
- Update README to support Node.js v18 or higher (instead of v18 to v24)
- Add Current releases to Node.js support policy

## CI Optimization Effect

| Version | lint | build | test | coverage |
|---------|------|-------|------|----------|
| 18.x | - | ✅ | ✅ | - |
| 20.x | - | ✅ | ✅ | - |
| 22.x | - | ✅ | ✅ | - |
| 24.x | ✅ | ✅ | ✅ | ✅ |

## Test plan

- [ ] Verify CI passes on all Node.js versions (18, 20, 22, 24)
- [ ] Verify lint runs only on 24.x
- [ ] Verify coverage is collected only on 24.x
- [ ] If `ubuntu-slim` causes issues, revert to `ubuntu-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)