### PR TITLE
chore: upgrade osv-scanner-action to v2.3.5 and override yaml

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   scan-scheduled:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@f8af5221bae5d45891ae7a23c2f3d0c938334355" # v1.8.2
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@c51854704019a247608d928f370c98740469d4b5" # v2.3.5
     with:
       # Example of specifying custom arguments
       scan-args: |-
@@ -39,7 +39,7 @@ jobs:
         ./
   scan-pr:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@f8af5221bae5d45891ae7a23c2f3d0c938334355" # v1.8.2
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@c51854704019a247608d928f370c98740469d4b5" # v2.3.5
     with:
       # Example of specifying custom arguments
       scan-args: |-

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -18,6 +18,8 @@ on:
     branches: [ "main" ]
   push:
     branches: [ "main" ]
+  schedule:
+    - cron: '0 3 * * 1'
 
 permissions:
   # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "packageManager": "pnpm@10.30.2",
   "pnpm": {
     "overrides": {
-      "yaml": ">=2.8.3"
+      "yaml": "^2.8.3"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,5 +73,10 @@
     "typescript-eslint": "^8.56.0",
     "vitest": "^3.2.4"
   },
-  "packageManager": "pnpm@10.30.2"
+  "packageManager": "pnpm@10.30.2",
+  "pnpm": {
+    "overrides": {
+      "yaml": ">=2.8.3"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  yaml: '>=2.8.3'
+
 importers:
 
   .:
@@ -19,7 +22,7 @@ importers:
         version: 8.56.1(eslint@10.0.2)(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.9.2)(yaml@2.8.1))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.9.2))
       eslint:
         specifier: ^10.0.0
         version: 10.0.2
@@ -31,7 +34,7 @@ importers:
         version: 6.1.0
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1)
+        version: 8.5.0(postcss@8.5.6)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -40,7 +43,7 @@ importers:
         version: 8.56.1(eslint@10.0.2)(typescript@5.9.3)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.2)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.2)
 
 packages:
 
@@ -1180,7 +1183,7 @@ packages:
       jiti: '>=1.21.0'
       postcss: '>=8.0.9'
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: '>=2.8.3'
     peerDependenciesMeta:
       jiti:
         optional: true
@@ -1402,7 +1405,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: '>=2.8.3'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1482,11 +1485,6 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
-
-  yaml@2.8.1:
-    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -1935,7 +1933,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.9.2)(yaml@2.8.1))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.9.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -1950,7 +1948,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.2)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -1962,13 +1960,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.9.2)(yaml@2.8.1))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.9.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.9.2)(yaml@2.8.1)
+      vite: 7.3.1(@types/node@24.9.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -2472,12 +2470,11 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.6)(yaml@2.8.1):
+  postcss-load-config@6.0.1(postcss@8.5.6):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       postcss: 8.5.6
-      yaml: 2.8.1
 
   postcss@8.5.6:
     dependencies:
@@ -2632,7 +2629,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.0(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1):
+  tsup@8.5.0(postcss@8.5.6)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.12)
       cac: 6.7.14
@@ -2643,7 +2640,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.6)(yaml@2.8.1)
+      postcss-load-config: 6.0.1(postcss@8.5.6)
       resolve-from: 5.0.0
       rollup: 4.60.0
       source-map: 0.8.0-beta.0
@@ -2685,13 +2682,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@3.2.4(@types/node@24.9.2)(yaml@2.8.1):
+  vite-node@3.2.4(@types/node@24.9.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@24.9.2)(yaml@2.8.1)
+      vite: 7.3.1(@types/node@24.9.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2706,7 +2703,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@24.9.2)(yaml@2.8.1):
+  vite@7.3.1(@types/node@24.9.2):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -2717,13 +2714,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.9.2
       fsevents: 2.3.3
-      yaml: 2.8.1
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.9.2)(yaml@2.8.1):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.9.2):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.9.2)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.9.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -2741,8 +2737,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@24.9.2)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@24.9.2)(yaml@2.8.1)
+      vite: 7.3.1(@types/node@24.9.2)
+      vite-node: 3.2.4(@types/node@24.9.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -2791,8 +2787,5 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.1.2
-
-  yaml@2.8.1:
-    optional: true
 
   yocto-queue@0.1.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  yaml: '>=2.8.3'
+  yaml: ^2.8.3
 
 importers:
 
@@ -1183,7 +1183,7 @@ packages:
       jiti: '>=1.21.0'
       postcss: '>=8.0.9'
       tsx: ^4.8.1
-      yaml: '>=2.8.3'
+      yaml: ^2.8.3
     peerDependenciesMeta:
       jiti:
         optional: true
@@ -1405,7 +1405,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: '>=2.8.3'
+      yaml: ^2.8.3
     peerDependenciesMeta:
       '@types/node':
         optional: true


### PR DESCRIPTION
## Summary

- main ブランチの `scan-scheduled / osv-scan` が `yaml@2.8.1` の脆弱性 (GHSA-48c2-rrv3-qjmp) で失敗していた問題を解消するため、`pnpm.overrides` で `yaml@>=2.8.3` を指定。`yaml` は `postcss-load-config` の optional peer dep のみで、本プロジェクトは PostCSS 設定ファイルを使っていないため、override の結果 `yaml` は依存ツリーから完全に削除される。
- OSV-Scanner ワークフローの reusable workflow 参照を v1.8.2 (SHA `f8af5221...`) から **v2.3.5** (SHA `c51854704019a247608d928f370c98740469d4b5`) に更新。v2.3.5 の内部実装では `actions/checkout@v6.0.1`, `actions/upload-artifact@v6.0.0`, `github/codeql-action/upload-sarif@v4.31.10` が使われており、Annotations の `Node.js 20 actions are deprecated` 警告が解消される。

> [!NOTE]
> vite@7.3.1 に関する 3 件の脆弱性 (GHSA-4w7w-66w2-5vf9 / GHSA-p9ff-h696-f583 / GHSA-v2wj-q39q-566r) は本 PR のスコープ外で、#103 (Dependabot: vite 7.3.1 → 7.3.2) のマージで解消予定。

## Test plan

- [x] `pnpm run build` がローカルで成功
- [x] `pnpm test` が 3508 tests (132 files) 全て成功
- [x] `pnpm lint` が成功
- [x] `pnpm-lock.yaml` から `yaml@2.8.1` のエントリが消えていることを確認
- [ ] この PR の `scan-pr / osv-scan` が SUCCESS であること
- [ ] この PR の Annotations に `Node.js 20 actions are deprecated` 警告が出ていないこと
- [ ] マージ後、main の `scan-scheduled / osv-scan` が SUCCESS で、Annotations に Node.js 20 警告が出ていないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * OSV security scanner updated to a newer pinned release and configured to run on a weekly scheduled cron for recurring vulnerability scans.
  * Added a pnpm override constraining the yaml dependency to ^2.8.3 to ensure consistent package resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->