### PR TITLE
release: v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Removed
 
+## [1.0.4] - 2026-04-11
+
+### Changed
+
+- Update `vite` from 7.1.12 to 7.3.2 (indirect dev dependency)
+- Update `brace-expansion` from 2.0.2 to 2.0.3 (indirect dev dependency)
+- Update `picomatch` from 4.0.3 to 4.0.4 (indirect dev dependency)
+
+### Fixed
+
+- Override `yaml` to `^2.8.3` to drop the vulnerable `yaml@2.8.1` (GHSA-48c2-rrv3-qjmp); `yaml` is only an optional peer dependency of `postcss-load-config`, which this project does not use
+
 ## [1.0.3] - 2026-03-25
 
 ### Fixed

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,12 @@
-## [1.0.3] - 2026-03-25
+## [1.0.4] - 2026-04-11
+
+### Changed
+
+- Update `vite` from 7.1.12 to 7.3.2 (indirect dev dependency)
+- Update `brace-expansion` from 2.0.2 to 2.0.3 (indirect dev dependency)
+- Update `picomatch` from 4.0.3 to 4.0.4 (indirect dev dependency)
 
 ### Fixed
 
-- Update `flatted` from 3.3.3 to 3.4.2 to fix Prototype Pollution and unbounded recursion DoS via `parse()`
-- Update `rollup` from 4.52.5 to 4.60.0 to fix Arbitrary File Write via Path Traversal
+- Override `yaml` to `^2.8.3` to drop the vulnerable `yaml@2.8.1` (GHSA-48c2-rrv3-qjmp); `yaml` is only an optional peer dependency of `postcss-load-config`, which this project does not use
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chronia",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "description": "A modern, lightweight TypeScript date/time utility library with comprehensive formatting, parsing, and manipulation capabilities.",
   "license": "MIT",


### PR DESCRIPTION
## Release v1.0.4

This PR prepares the release for version 1.0.4.

### Changes

## [1.0.4] - 2026-04-11

### Changed

- Update `vite` from 7.1.12 to 7.3.2 (indirect dev dependency)
- Update `brace-expansion` from 2.0.2 to 2.0.3 (indirect dev dependency)
- Update `picomatch` from 4.0.3 to 4.0.4 (indirect dev dependency)

### Fixed

- Override `yaml` to `^2.8.3` to drop the vulnerable `yaml@2.8.1` (GHSA-48c2-rrv3-qjmp); `yaml` is only an optional peer dependency of `postcss-load-config`, which this project does not use

### Checklist

- [x] Version bumped in package.json
- [x] CHANGELOG.md updated
- [x] RELEASE.md created
- [x] All tests passing
- [x] Build successful
- [ ] PR approved and merged
- [ ] Release created with `/release:publish`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Release**
  * Version 1.0.4 released

* **Security Fixes**
  * Addressed vulnerability in yaml dependency by updating to ^2.8.3

* **Chores**
  * Updated indirect development dependencies (vite, brace-expansion, picomatch)
  * Updated release documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->